### PR TITLE
Feature/Facebook_login

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'pry-byebug'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,7 @@ GEM
     chromedriver-helper (2.1.1)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
+    coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -141,6 +142,12 @@ GEM
       actionpack (>= 4.2)
       omniauth (>= 1.3.1)
     orm_adapter (0.5.0)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-byebug (3.8.0)
+      byebug (~> 11.0)
+      pry (~> 0.10)
     public_suffix (4.0.3)
     puma (3.12.2)
     rack (2.1.2)
@@ -249,6 +256,7 @@ DEPENDENCIES
   omniauth
   omniauth-facebook
   omniauth-rails_csrf_protection
+  pry-byebug
   puma (~> 3.11)
   rails (~> 5.2.4, >= 5.2.4.1)
   rails-i18n

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,10 @@
 class ApplicationController < ActionController::Base
   before_action  :authenticate_user!
 
+  def after_sign_out_path_for(resource)
+    new_user_session_path 
+  end
+
   rescue_from Exception, with: :error_500 unless Rails.env.development?
 
   rescue_from AbstractController::ActionNotFound, with: :error_404 unless Rails.env.development?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action  :authenticate_user!
 
-  def after_sign_out_path_for(resource)
-    new_user_session_path 
-  end
-
   rescue_from Exception, with: :error_500 unless Rails.env.development?
 
   rescue_from AbstractController::ActionNotFound, with: :error_404 unless Rails.env.development?
@@ -17,5 +13,9 @@ class ApplicationController < ActionController::Base
 
   def error_404
     render file: "#{Rails.root}/public/404.html", layout: false, status: 404
+  end
+
+  def after_sign_out_path_for(resource)
+    new_user_session_path 
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::Base
+  before_action  :authenticate_user!
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,17 @@
 class ApplicationController < ActionController::Base
   before_action  :authenticate_user!
+
+  rescue_from Exception, with: :error_500 unless Rails.env.development?
+
+  rescue_from AbstractController::ActionNotFound, with: :error_404 unless Rails.env.development?
+  rescue_from ActionController::RoutingError, with: :error_404 unless Rails.env.development?
+  rescue_from ActiveRecord::RecordNotFound, with: :error_404 unless Rails.env.development?
+
+  def error_500
+    render file: "#{Rails.root}/public/500.html", layout: false, status: 500
+  end
+
+  def error_404
+    render file: "#{Rails.root}/public/404.html", layout: false, status: 404
+  end
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,4 +1,6 @@
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  skip_before_action :authenticate_user!
+
   def facebook
     callback_from :facebook
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable, :omniauthable
   
   def self.find_for_oauth(auth)
-    user = User.where(uid: auth.uid, provider: auth.provider).first
+    user = User.find_by(uid: auth.uid, provider: auth.provider)
 
     unless user
       user = User.create(uid: auth.uid, provider: auth.provider, name: auth.extra.raw_info.name, email: User.dummy_email(auth), token: auth.credentials.token, image: auth.info.image,  password: Devise.friendly_token[0, 20])

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ApplicationRecord
     user = User.where(uid: auth.uid, provider: auth.provider).first
 
     unless user
-      user = User.create(uid: auth.uid, provider: auth.provider, email: User.dummy_email(auth), password: Devise.friendly_token[0, 20])
+      user = User.create(uid: auth.uid, provider: auth.provider, name: auth.extra.raw_info.name, email: User.dummy_email(auth), token: auth.credentials.token, image: auth.info.image,  password: Devise.friendly_token[0, 20])
     end
 
     user

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,2 +1,4 @@
-<h1>Home#index</h1>
-<p>Find me in app/views/home/index.html.erb</p>
+<h1>プロフィール情報</h1>
+<p>ユーザー名:<%= current_user.name %></p>
+<p>メールアドレス：<%= current_user.email %></p>
+<p>プロフィール画像<%= image_tag(current_user.image, size: 100) %></p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,13 @@
   </head>
 
   <body>
+    <% if user_signed_in? %>
+      <%= link_to 'Edit profile', edit_user_registration_path, class: 'navbar-link' %> |
+      <%= link_to "Logout", destroy_user_session_path, method: :delete, class: 'navbar-link'  %>
+    <% else %>
+      <%= link_to "Sign up", new_user_registration_path, class: 'navbar-link'  %> |
+      <%= link_to "Login", new_user_session_path, class: 'navbar-link'  %>
+    <% end %>
     <p class="notice"><%= notice %></p>
     <p class="alert"><%= alert %></p>
     <%= yield %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,7 @@ module LabtaskApi
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
     config.i18n.default_locale = :ja
+    config.autoload_paths += %W(#{config.root}/lib)
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -265,10 +265,11 @@ Devise.setup do |config|
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.
   #
-  # config.warden do |manager|
-  #   manager.intercept_401 = false
-  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
-  # end
+   config.warden do |manager|
+     manager.failure_app = CustomAuthenticationFailure
+     # manager.intercept_401 = false
+     # manager.default_strategies(scope: :user).unshift :some_external_strategy
+   end
 
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@ Rails.application.routes.draw do
   root "home#index"
   devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  get "/errors", to: "application#error_404"
 end

--- a/db/migrate/20200205134138_add_columns_to_users.rb
+++ b/db/migrate/20200205134138_add_columns_to_users.rb
@@ -2,5 +2,8 @@ class AddColumnsToUsers < ActiveRecord::Migration[5.2]
   def change
     add_column :users, :uid, :string
     add_column :users, :provider, :string
+    add_column :users, :name, :string
+    add_column :users, :token, :string
+    add_column :users, :image, :string
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -22,6 +22,9 @@ ActiveRecord::Schema.define(version: 2020_02_05_134138) do
     t.datetime "updated_at", null: false
     t.string "uid"
     t.string "provider"
+    t.string "name"
+    t.string "token"
+    t.string "image"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/lib/custom_authentication_failure.rb
+++ b/lib/custom_authentication_failure.rb
@@ -1,0 +1,6 @@
+class CustomAuthenticationFailure < Devise::FailureApp 
+  protected 
+    def redirect_url 
+      errors_path
+    end 
+  end 


### PR DESCRIPTION
<h3>内容</h3>
ログイン後の機能全般の追加。ログイン後のプロフィール表示と認証エラー画面の実装やログアウトの実装を行ないました。

<h3>実装</h3>
<h5>ログアウト機能を加える:</h5> <p>- 未ログイン時には、ログインと登録へのリンクを表示して
ログイン時には、ログアウトと編集へのリンクを表示。また、ログアウト時に特定のパスへリダイレクトされるようにしました</p>

<h5>ログイン後プロフィールの表示:</h5>  <p>- root_pathにプロフィールを表示できるようにしました。(名前、メールアドレス、プロフィール画像),　また今後に使用するのでトークンも取得できるようにしました。 </p>

<h5>認証失敗時に特定のエラー画面を表示:  </h5> <p>- railsに最初から用意されているエラーページ(404, 500)を用いて認証が失敗した時、特定のエラー画面にリダイレクトされるようにしました。</p>



参考資料

https://hackernoon.com/how-to-integrate-devise-and-omniauth-facebook-authentication-to-your-rails-app-tyiv3xpi
https://qiita.com/mosa_siru/items/8dc8bb098f1dea6ffb5d
http://kgmx.hatenablog.com/entry/2015/08/10/101349
https://qiita.com/kumasuke/items/7d5c47b4a40f6912adf2